### PR TITLE
Change Spark version to 3.3.2 and add extra libraries (Minio s3a, Kaf…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,10 @@ services:
     entrypoint: >
       /bin/sh -c "
       until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
-      # /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;
       tail -f /dev/null
+      # /usr/bin/mc rm -r --force minio/warehouse; Prevent the warehouse from being deleted upon restart.
       "
 networks:
   iceberg_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse;
+      # /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;
       tail -f /dev/null

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -48,18 +48,18 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 
 WORKDIR ${SPARK_HOME}
 
-ENV SPARK_VERSION=3.5.2
-ENV SPARK_MAJOR_VERSION=3.5
+ENV SPARK_VERSION=3.3.2
+ENV SPARK_MAJOR_VERSION=3.3
 ENV ICEBERG_VERSION=1.6.0
 
 # Download spark
 RUN mkdir -p ${SPARK_HOME} \
- && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+ && curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3-scala2.13.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 
 # Download iceberg spark runtime
-RUN curl https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12/${ICEBERG_VERSION}/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12-${ICEBERG_VERSION}.jar
+RUN curl https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.13/${ICEBERG_VERSION}/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.13-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.13-${ICEBERG_VERSION}.jar
 
 # Download AWS bundle
 RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-aws-bundle-${ICEBERG_VERSION}.jar
@@ -126,6 +126,18 @@ RUN chmod u+x /opt/spark/sbin/* && \
 COPY .pyiceberg.yaml /root/.pyiceberg.yaml
 
 COPY entrypoint.sh .
+
+# Add libraries for MinIO access and fixes.
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.2/hadoop-aws-3.3.2.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/3.3.2/hadoop-common-3.3.2.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.172/aws-java-sdk-bundle-1.12.172.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.257/bundle-2.17.257.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/2.17.257/url-connection-client-2.17.257.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/org/apache/spark/spark-hadoop-cloud_2.13/3.3.2/spark-hadoop-cloud_2.13-3.3.2.jar -P /opt/spark/jars/
+RUN wget https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.13/0.50.0/nessie-spark-extensions-3.3_2.13-0.50.0.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/org/apache/spark/spark-sql-kafka-0-10_2.13/3.3.2/spark-sql-kafka-0-10_2.13-3.3.2.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/3.3.2/kafka-clients-3.3.2.jar -P /opt/spark/jars/
+RUN wget https://repo1.maven.org/maven2/org/apache/spark/spark-token-provider-kafka-0-10_2.13/3.3.2/spark-token-provider-kafka-0-10_2.13-3.3.2.jar -P /opt/spark/jars/
 
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["notebook"]

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -138,6 +138,9 @@ RUN wget https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-ext
 RUN wget https://repo1.maven.org/maven2/org/apache/spark/spark-sql-kafka-0-10_2.13/3.3.2/spark-sql-kafka-0-10_2.13-3.3.2.jar -P /opt/spark/jars/
 RUN wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/3.3.2/kafka-clients-3.3.2.jar -P /opt/spark/jars/
 RUN wget https://repo1.maven.org/maven2/org/apache/spark/spark-token-provider-kafka-0-10_2.13/3.3.2/spark-token-provider-kafka-0-10_2.13-3.3.2.jar -P /opt/spark/jars/
+# Patch antlr4 to higher version because we are using higher version Iceberg (1.1.0 vs. 1.6.0).
+RUN wget https://repo1.maven.org/maven2/org/antlr/antlr4-runtime/4.9.3/antlr4-runtime-4.9.3.jar -P /opt/spark/jars/
+RUN rm /opt/spark/jars/antlr4-runtime-4.8.jar
 
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["notebook"]


### PR DESCRIPTION
# Background
* I have tested the original Spark 3.5.4 and it works great for the example, especially when using Iceberg library to write the parquet file to the Minio.
* However, when accessing the Minio bucket directly, I got error related s3a library missing.
* Adding Spark 3.5.4 AWS libraries (hadoop-aws and aws-java-bundle) directly to the image does not help as I am getting different errors.
* Looking at the openlake [example ](https://github.com/minio/openlake/blob/main/spark/docker/Dockerfile)  by Minio developers, it seems that it is working with Spark 3.3.2.
* An example on [Medium](https://medium.com/@abdullahdurrani/working-with-minio-and-spark-8b4729daec6e) also indicates that it should work with an older version.

# Purpose
* Change the Spark version to 3.3.2.
* Add extra libraries so it can work with Minio directly outside of Iceberg libraries.

# Testing
* Prior to the image, I used local deployment and the following code works for me with the config in this PR.
```python
from pyspark.sql import SparkSession

spark = SparkSession.builder \
    .appName("DebugMinIO") \
    .config("spark.hadoop.fs.s3a.access.key", "minioadmin") \
    .config("spark.hadoop.fs.s3a.secret.key", "minioadmin") \
    .config("spark.hadoop.fs.s3a.endpoint", "http://localhost:9000") \
    .config("spark.hadoop.fs.s3a.path.style.access", "true") \
    .config("fs.s3a.attempts.maximum", "1") \
    .config("fs.s3a.connection.establish.timeout", "5000") \
    .config("fs.s3a.connection.timeout", "10000") \
    .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false") \
    .config("spark.driver.extraJavaOptions", "-Dorg.apache.hadoop.fs.s3a.s3guard.ddb.table=none") \
    .getOrCreate()

from pyspark.sql.functions import rand, monotonically_increasing_id
# Create DataFrame with random values
df = spark.range(10).withColumn("col1", rand()).withColumn("col2", rand()).withColumn("col3", rand())

df.write.format("csv").option("header", "true").save("s3a://bucket1/")
``` 