### PR TITLE
Remove `docker-compose.yml` version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3"
-
 services:
   spark-iceberg:
     image: tabulario/spark-iceberg


### PR DESCRIPTION
Causes:

```
WARN[0000] /Users/fokko.driesprong/Desktop/docker-spark-iceberg/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```