### PR TITLE
modified:   spark/notebooks/Iceberg - Integrated Audits Demo.ipynb

### DIFF
--- a/spark/notebooks/Iceberg - Integrated Audits Demo.ipynb
+++ b/spark/notebooks/Iceberg - Integrated Audits Demo.ipynb
@@ -357,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Since `boroughs` and `required_boroughs` are both sets (array of distinct items),\n",
+    "# Since `boroughs` and `expected_boroughs` are both sets (array of distinct items),\n",
     "# we can confirm that they match by checking that the lengths of the sets are equal\n",
     "# to eachother as well as to the union of both sets.\n",
     "if len(boroughs) != len(expected_boroughs) != len(set.union(boroughs, expected_boroughs)):\n",


### PR DESCRIPTION
Since `boroughs` and `expected_boroughs` are both sets (array of distinct items). Corrected required_boroughs to expected_boroughs